### PR TITLE
Fix for error messages when VPC is used and some other minor optimizations

### DIFF
--- a/locust_swarm/config.py
+++ b/locust_swarm/config.py
@@ -12,6 +12,7 @@ DEFAULT_MASTER_BOOTSTRAP_DIR = './bootstrap-master'
 DEFAULT_SLAVE_BOOTSTRAP_DIR = './bootstrap-slave'
 DEFAULT_NUM_SLAVES = 5
 DEFAULT_CUSTOM_TAG_NAME = 'MachineRole'
+DEFAULT_INSTANCE_TAG_NAME = 'Name'
 
 
 def _parse(path_to_config=DEFAULT_CFG_FILEPATH):

--- a/locust_swarm/providers/amazon.py
+++ b/locust_swarm/providers/amazon.py
@@ -200,10 +200,10 @@ def _get_or_create_security_group(
 
 
 def _get_security_group(conn, security_group_name):
-    try:
-        return conn.get_all_security_groups([security_group_name])[0]
-    except:
-        return None
+    for security_group in conn.get_all_security_groups():
+        if security_group_name == security_group.name:
+            return security_group
+    return None
 
 
 def _create_security_group(conn,

--- a/locust_swarm/providers/amazon.py
+++ b/locust_swarm/providers/amazon.py
@@ -24,16 +24,28 @@ def get_master_ip_address(config):
     return None
 
 
+def get_security_group_from_role(config, role_name):
+    aws_region = config.get('aws', 'aws_region')
+    aws_access_key_id = config.get('aws', 'access_key_id')
+    aws_secret_access_key = config.get('aws', 'secret_access_key')
+
+    return _get_or_create_security_group_from_role(
+        aws_region,
+        aws_access_key_id,
+        aws_secret_access_key,
+        role_name)
+
+
 def get_slave_reservations(config):
     return _get_instances_by_role(config, DEFAULT_SLAVE_ROLE_NAME)
 
 
-def create_master(config):
-    return _run_instances_from_config(config, DEFAULT_MASTER_ROLE_NAME)
+def create_master(config, security_group):
+    return _run_instances_from_config(config, DEFAULT_MASTER_ROLE_NAME, security_group)
 
 
-def create_slave(config):
-    return _run_instances_from_config(config, DEFAULT_SLAVE_ROLE_NAME)
+def create_slave(config, security_group):
+    return _run_instances_from_config(config, DEFAULT_SLAVE_ROLE_NAME, security_group)
 
 
 def update_master_security_group(config):
@@ -90,7 +102,7 @@ def _get_instances(aws_region,
     return conn.get_all_instances(filters=filters)
 
 
-def _run_instances_from_config(config, role_name):
+def _run_instances_from_config(config, role_name, security_group):
     aws_region = config.get('aws', 'aws_region')
     aws_access_key_id = config.get('aws', 'access_key_id')
     aws_secret_access_key = config.get('aws', 'secret_access_key')
@@ -98,12 +110,6 @@ def _run_instances_from_config(config, role_name):
     ami_instance_type = config.get('aws', 'ami_instance_type')
     aws_key_name = config.get('aws', 'aws_key_name', None)
     tag_dict = {DEFAULT_CUSTOM_TAG_NAME: role_name, DEFAULT_INSTANCE_TAG_NAME: role_name.replace('-', ' ').title()}
-
-    security_group = _get_or_create_security_group_from_role(
-        aws_region,
-        aws_access_key_id,
-        aws_secret_access_key,
-        role_name)
 
     security_group_ids = [security_group.id] if security_group else []
 

--- a/locust_swarm/providers/amazon.py
+++ b/locust_swarm/providers/amazon.py
@@ -41,11 +41,17 @@ def get_slave_reservations(config):
 
 
 def create_master(config, security_group):
-    return _run_instances_from_config(config, DEFAULT_MASTER_ROLE_NAME, security_group)
+    return _run_instances_from_config(
+        config,
+        DEFAULT_MASTER_ROLE_NAME,
+        security_group)
 
 
 def create_slave(config, security_group):
-    return _run_instances_from_config(config, DEFAULT_SLAVE_ROLE_NAME, security_group)
+    return _run_instances_from_config(
+        config,
+        DEFAULT_SLAVE_ROLE_NAME,
+        security_group)
 
 
 def update_master_security_group(config):
@@ -64,9 +70,23 @@ def update_master_security_group(config):
     if slave_group and master_group:
         try:
             if master_group.vpc_id:
-                master_group.authorize(ip_protocol='icmp', from_port=-1, to_port=-1, src_group=slave_group)
-                master_group.authorize(ip_protocol='tcp', from_port=0, to_port=65535, src_group=slave_group)
-                master_group.authorize(ip_protocol='udp', from_port=0, to_port=65535, src_group=slave_group)
+                master_group.authorize(
+                    ip_protocol='icmp',
+                    from_port=-1,
+                    to_port=-1,
+                    src_group=slave_group)
+
+                master_group.authorize(
+                    ip_protocol='tcp',
+                    from_port=0,
+                    to_port=65535,
+                    src_group=slave_group)
+
+                master_group.authorize(
+                    ip_protocol='udp',
+                    from_port=0,
+                    to_port=65535,
+                    src_group=slave_group)
             else:
                 master_group.authorize(src_group=slave_group)
         except:
@@ -74,9 +94,23 @@ def update_master_security_group(config):
 
         try:
             if slave_group.vpc_id:
-                slave_group.authorize(ip_protocol='icmp', from_port=-1, to_port=-1, src_group=master_group)
-                slave_group.authorize(ip_protocol='tcp', from_port=0, to_port=65535, src_group=master_group)
-                slave_group.authorize(ip_protocol='udp', from_port=0, to_port=65535, src_group=master_group)
+                slave_group.authorize(
+                    ip_protocol='icmp',
+                    from_port=-1,
+                    to_port=-1,
+                    src_group=master_group)
+
+                slave_group.authorize(
+                    ip_protocol='tcp',
+                    from_port=0,
+                    to_port=65535,
+                    src_group=master_group)
+
+                slave_group.authorize(
+                    ip_protocol='udp',
+                    from_port=0,
+                    to_port=65535,
+                    src_group=master_group)
             else:
                 slave_group.authorize(src_group=master_group)
         except:
@@ -115,7 +149,9 @@ def _run_instances_from_config(config, role_name, security_group):
     ami_id = config.get('aws', 'ami_id')
     ami_instance_type = config.get('aws', 'ami_instance_type')
     aws_key_name = config.get('aws', 'aws_key_name', None)
-    tag_dict = {DEFAULT_CUSTOM_TAG_NAME: role_name, DEFAULT_INSTANCE_TAG_NAME: role_name.replace('-', ' ').title()}
+    tag_dict = {
+        DEFAULT_CUSTOM_TAG_NAME: role_name,
+        DEFAULT_INSTANCE_TAG_NAME: role_name.replace('-', ' ').title()}
 
     security_group_ids = [security_group.id] if security_group else []
 

--- a/locust_swarm/providers/amazon.py
+++ b/locust_swarm/providers/amazon.py
@@ -63,16 +63,22 @@ def update_master_security_group(config):
 
     if slave_group and master_group:
         try:
-            if master_group.rules == []:
-                master_group.vpc_id = None
-            master_group.authorize(src_group=slave_group)
+            if master_group.vpc_id:
+                master_group.authorize(ip_protocol='icmp', from_port=-1, to_port=-1, src_group=slave_group)
+                master_group.authorize(ip_protocol='tcp', from_port=0, to_port=65535, src_group=slave_group)
+                master_group.authorize(ip_protocol='udp', from_port=0, to_port=65535, src_group=slave_group)
+            else:
+                master_group.authorize(src_group=slave_group)
         except:
             pass
 
         try:
-            if slave_group.rules == []:
-                slave_group.vpc_id = None
-            slave_group.authorize(src_group=master_group)
+            if slave_group.vpc_id:
+                slave_group.authorize(ip_protocol='icmp', from_port=-1, to_port=-1, src_group=master_group)
+                slave_group.authorize(ip_protocol='tcp', from_port=0, to_port=65535, src_group=master_group)
+                slave_group.authorize(ip_protocol='udp', from_port=0, to_port=65535, src_group=master_group)
+            else:
+                slave_group.authorize(src_group=master_group)
         except:
             pass
 

--- a/locust_swarm/providers/amazon.py
+++ b/locust_swarm/providers/amazon.py
@@ -50,11 +50,15 @@ def update_master_security_group(config):
 
     if slave_group and master_group:
         try:
+            if master_group.rules == []:
+                master_group.vpc_id = None
             master_group.authorize(src_group=slave_group)
         except:
             pass
 
         try:
+            if slave_group.rules == []:
+                slave_group.vpc_id = None
             slave_group.authorize(src_group=master_group)
         except:
             pass

--- a/locust_swarm/providers/amazon.py
+++ b/locust_swarm/providers/amazon.py
@@ -5,6 +5,7 @@ from boto.ec2 import connect_to_region
 from ..config import DEFAULT_MASTER_ROLE_NAME
 from ..config import DEFAULT_SLAVE_ROLE_NAME
 from ..config import DEFAULT_CUSTOM_TAG_NAME
+from ..config import DEFAULT_INSTANCE_TAG_NAME
 
 from time import sleep
 
@@ -96,7 +97,7 @@ def _run_instances_from_config(config, role_name):
     ami_id = config.get('aws', 'ami_id')
     ami_instance_type = config.get('aws', 'ami_instance_type')
     aws_key_name = config.get('aws', 'aws_key_name', None)
-    tag_dict = {DEFAULT_CUSTOM_TAG_NAME: role_name}
+    tag_dict = {DEFAULT_CUSTOM_TAG_NAME: role_name, DEFAULT_INSTANCE_TAG_NAME: role_name.replace('-', ' ').title()}
 
     security_group = _get_or_create_security_group_from_role(
         aws_region,

--- a/locust_swarm/runner.py
+++ b/locust_swarm/runner.py
@@ -69,7 +69,8 @@ def swarm_up_master(args):
 
     cfg = get_config(args.config)
 
-    security_group = get_security_group_from_role(cfg, DEFAULT_MASTER_ROLE_NAME)
+    security_group = get_security_group_from_role(
+        cfg, DEFAULT_MASTER_ROLE_NAME)
 
     create_master(cfg, security_group)
 
@@ -150,7 +151,9 @@ def _bootstrap(abs_bootstrap_dir_path):
         sudo("chmod +x /tmp/locust/{0}/bootstrap.sh".format(dir_name))
         sudo("/tmp/locust/{0}/bootstrap.sh".format(dir_name))
 
-def _wait_for_slave_reservations(cfg, reservations_num, max_tries=30, sleep_interval=5):
+
+def _wait_for_slave_reservations(
+        cfg, reservations_num, max_tries=30, sleep_interval=5):
     tries = 0
     online_hosts = []
     while True:
@@ -158,7 +161,9 @@ def _wait_for_slave_reservations(cfg, reservations_num, max_tries=30, sleep_inte
             logging.info("All {0} hosts are online".format(reservations_num))
             break
         if tries > max_tries:
-            logging.warning("Timeout. Only {0} of {1} hosts came online.".format(len(online_hosts), reservations_num))
+            logging.warning(
+                "Timeout. Only {0} of {1} hosts came online.".format(
+                    len(online_hosts), reservations_num))
             break
         reservations = get_slave_reservations(cfg)
         for reservation in reservations:
@@ -168,6 +173,7 @@ def _wait_for_slave_reservations(cfg, reservations_num, max_tries=30, sleep_inte
                 logging.info("Host {0} is now ssh-able.".format(ip_address))
         tries += 1
         time.sleep(sleep_interval)
+
 
 # TODO: Shouldn't leak these calls through
 def _update_role_defs(reservations, role_key):

--- a/locust_swarm/runner.py
+++ b/locust_swarm/runner.py
@@ -104,22 +104,10 @@ def swarm_up_slaves(args):
     pool.close()
     pool.join()
 
+    _wait_for_slave_reservations(cfg, args.num_slaves)
+
     update_master_security_group(cfg)
-
-    tries = 0
-    while True:
-        active_slaves = get_slave_reservations(cfg)
-        if len(active_slaves) == args.num_slaves:
-            logging.info("Success. All {0} slaves online.".format(args.num_slaves))
-            break
-        elif tries > 60:
-            logging.warning("Timeout. Only {0} of {1} slave instances have responded.".format(len(active_slaves), args.num_slaves))
-            break
-        else:
-            tries += 1
-            time.sleep(5)
-
-    _update_role_defs(active_slaves, 'slave')
+    _update_role_defs(get_slave_reservations(cfg), 'slave')
     env.user = cfg.get('fabric', 'user', None)
     env.key_filename = cfg.get('fabric', 'key_filename', None)
     env.parallel = True
@@ -162,6 +150,24 @@ def _bootstrap(abs_bootstrap_dir_path):
         sudo("chmod +x /tmp/locust/{0}/bootstrap.sh".format(dir_name))
         sudo("/tmp/locust/{0}/bootstrap.sh".format(dir_name))
 
+def _wait_for_slave_reservations(cfg, reservations_num, max_tries=30, sleep_interval=5):
+    tries = 0
+    online_hosts = []
+    while True:
+        if (len(online_hosts) == reservations_num):
+            logging.info("All {0} hosts are online".format(reservations_num))
+            break
+        if tries > max_tries:
+            logging.warning("Timeout. Only {0} of {1} hosts came online.".format(len(online_hosts), reservations_num))
+            break
+        reservations = get_slave_reservations(cfg)
+        for reservation in reservations:
+            ip_address = reservation.instances[0].ip_address
+            if ip_address not in online_hosts and can_ssh(ip_address):
+                online_hosts.append(ip_address)
+                logging.info("Host {0} is now ssh-able.".format(ip_address))
+        tries += 1
+        time.sleep(sleep_interval)
 
 # TODO: Shouldn't leak these calls through
 def _update_role_defs(reservations, role_key):

--- a/locust_swarm/runner.py
+++ b/locust_swarm/runner.py
@@ -97,10 +97,20 @@ def swarm_up_slaves(args):
 
     update_master_security_group(cfg)
 
-    # TODO: Hack for now, should check for ssh-ability
-    time.sleep(5)
+    tries = 0
+    while True:
+        active_slaves = get_slave_reservations(cfg)
+        if len(active_slaves) == args.num_slaves:
+            logging.info("Success. All {0} slaves online.".format(args.num_slaves))
+            break
+        elif tries > 60:
+            logging.warning("Timeout. Only {0} of {1} slave instances have responded.".format(len(active_slaves), args.num_slaves))
+            break
+        else:
+            tries += 1
+            time.sleep(5)
 
-    _update_role_defs(get_slave_reservations(cfg), 'slave')
+    _update_role_defs(active_slaves, 'slave')
     env.user = cfg.get('fabric', 'user', None)
     env.key_filename = cfg.get('fabric', 'key_filename', None)
     env.parallel = True

--- a/locust_swarm/runner.py
+++ b/locust_swarm/runner.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 
 from config import get_config
+from config import DEFAULT_SLAVE_ROLE_NAME
+from config import DEFAULT_MASTER_ROLE_NAME
 from fabric.api import env
 from fabric.api import put
 from fabric.api import roles
@@ -12,12 +14,14 @@ from fabric.state import connections
 from fabric.tasks import execute
 from helpers import get_abs_path
 from helpers import is_fabricable
+from helpers import can_ssh
 import logging
 from multiprocessing import Pool
 import os
 from providers.amazon import get_master_ip_address
 from providers.amazon import get_master_reservations
 from providers.amazon import get_slave_reservations
+from providers.amazon import get_security_group_from_role
 from providers.amazon import create_master
 from providers.amazon import create_slave
 from providers.amazon import update_master_security_group
@@ -64,7 +68,10 @@ def swarm_up_master(args):
     _validate_dirs(args)
 
     cfg = get_config(args.config)
-    create_master(cfg)
+
+    security_group = get_security_group_from_role(cfg, DEFAULT_MASTER_ROLE_NAME)
+
+    create_master(cfg, security_group)
 
     _update_role_defs(get_master_reservations(cfg), 'master')
     env.user = cfg.get('fabric', 'user', None)
@@ -85,12 +92,14 @@ def swarm_up_slaves(args):
 
     master_ip_address = get_master_ip_address(cfg)
 
+    security_group = get_security_group_from_role(cfg, DEFAULT_SLAVE_ROLE_NAME)
+
     if not master_ip_address:
         raise Exception("Unable to start slaves without a master. Please "
                         "bring up a master first.")
 
     for i in xrange(args.num_slaves):
-        pool.apply_async(create_slave, (cfg,))
+        pool.apply_async(create_slave, (cfg, security_group))
 
     pool.close()
     pool.join()


### PR DESCRIPTION
Issues summary:
- Fix for situation when a security group is assigned a valid vpc_id upon which the EC2 API expects 'ip_protocol', 'from_port' and 'to_port' parameters to be also supplied.
- Replace the fixed timeout and wait for SSH-ability of the slave instances.
- Fix for situation when several slave proceses running in parallel end up sending create a new security group request to the EC2 API resulting in error messages popping in the console saying that a security group with the specified name already exists. We make sure that the corresponding security group is already created before launching pool of processes.
- Add Name tag to EC2 locust-swarm instances to simplify their identification in the AWS console.
