### PR TITLE
Opens port 5557:5558 to allow master/slave communication

### DIFF
--- a/locust_swarm/providers/amazon.py
+++ b/locust_swarm/providers/amazon.py
@@ -163,6 +163,7 @@ def _get_or_create_security_group_from_role(aws_region,
 
     if role_name == DEFAULT_MASTER_ROLE_NAME:
         authorization_tuples.append(('tcp', 8089, 8089, '0.0.0.0/0'))
+        authorization_tuples.append(('tcp', 5557, 5558, '0.0.0.0/0'))
 
     return _get_or_create_security_group(
         aws_region,


### PR DESCRIPTION
Not sure whether locust changed this in recent versions, but your security group did not have ports 5557/5558 open, which is required for master/slave communication.

This PR amends these two ports.